### PR TITLE
Correction for empty files in getStringOfFile

### DIFF
--- a/plugins/org.but4reuse.utils/src/org/but4reuse/utils/files/FileUtils.java
+++ b/plugins/org.but4reuse.utils/src/org/but4reuse/utils/files/FileUtils.java
@@ -254,7 +254,8 @@ public class FileUtils {
 		for (String line : getLinesOfFile(file)) {
 			string.append(line + "\n");
 		}
-		string.setLength(string.length() - 1);
+		if (string.length() > 0) // If the file is empty the -1 causes an exception
+			string.setLength(string.length() - 1);
 		return string.toString();
 	}
 


### PR DESCRIPTION
When the file is empty no -1 is needed.