### PR TITLE
Pull request mfv

### DIFF
--- a/experimental/org.but4reuse.block.graphs/src/org/but4reuse/block/graphs/FCAWeaklyConnectedComponents.java
+++ b/experimental/org.but4reuse.block.graphs/src/org/but4reuse/block/graphs/FCAWeaklyConnectedComponents.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 
 import org.but4reuse.adaptedmodel.AdaptedArtefact;
 import org.but4reuse.adaptedmodel.AdaptedModelFactory;
@@ -47,7 +48,7 @@ public class FCAWeaklyConnectedComponents implements IBlockIdentification {
 			}
 			
 			// create graph
-			List<IElement> elements = AdaptedModelHelper.getElementsOfBlock(b);
+			HashSet<IElement> elements = AdaptedModelHelper.getElementsOfBlockHashSet(b);
 			DirectedGraph<IElement, DefaultEdge> graph = GraphUtils.createDirectedGraph(elements);
 			List<Set<IElement>> connectedSets = getConnectedSets(graph);
 			for (Set<IElement> connectedSet : connectedSets) {

--- a/experimental/org.but4reuse.graphs/src/org/but4reuse/graphs/utils/GraphUtils.java
+++ b/experimental/org.but4reuse.graphs/src/org/but4reuse/graphs/utils/GraphUtils.java
@@ -2,6 +2,7 @@ package org.but4reuse.graphs.utils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.but4reuse.adapters.IDependencyObject;
@@ -13,7 +14,7 @@ import org.jgrapht.graph.DefaultEdge;
 
 public class GraphUtils {
 	
-	public static DirectedGraph<IElement, DefaultEdge> createDirectedGraph(List<IElement> elements) {
+	public static DirectedGraph<IElement, DefaultEdge> createDirectedGraph(HashSet<IElement> elements) {
 		return createDirectedGraph(elements, false);
 	}
 
@@ -23,7 +24,7 @@ public class GraphUtils {
 	 * @param onlyContainment
 	 * @return A directed graph
 	 */
-	public static DirectedGraph<IElement, DefaultEdge> createDirectedGraph(List<IElement> elements,
+	public static DirectedGraph<IElement, DefaultEdge> createDirectedGraph(HashSet<IElement> elements,
 			boolean onlyContainment) {
 		DirectedGraph<IElement, DefaultEdge> graph = new DefaultDirectedGraph<IElement, DefaultEdge>(DefaultEdge.class);
 		// Add nodes

--- a/plugins/org.but4reuse.adapters.emf/META-INF/MANIFEST.MF
+++ b/plugins/org.but4reuse.adapters.emf/META-INF/MANIFEST.MF
@@ -11,9 +11,11 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.diffmerge.ui.gmf,
  org.eclipse.emf.ecore,
  org.eclipse.ui,
- org.but4reuse.adaptedmodel
+ org.but4reuse.adaptedmodel,
+ com.google.gson;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: org.but4reuse.adapters.emf,
- org.but4reuse.adapters.emf.helper
+ org.but4reuse.adapters.emf.helper,
+ serialization
 Bundle-Vendor: BUT4Reuse

--- a/plugins/org.but4reuse.adapters.emf/src/serialization/EMFAttributeElementSerializer.java
+++ b/plugins/org.but4reuse.adapters.emf/src/serialization/EMFAttributeElementSerializer.java
@@ -10,8 +10,23 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+/**
+ * This is a serializer for the gson export of EMFAttributeElements to be registered as TypeAdapter on the GsonBuilder
+ */
 public class EMFAttributeElementSerializer implements JsonSerializer<EMFAttributeElement> {
 
+	/**
+	 * Gson invokes this call-back method during serialization when it encounters a field of the specified type.
+	 * In the implementation of this call-back method, you should consider invoking
+	 * JsonSerializationContext.serialize(Object, Type) method to create JsonElements for any non-trivial field
+	 * of the src object. However, you should never invoke it on the src object itself since that will cause
+	 * an infinite loop (Gson will call your call-back method again).
+	 *
+	 * @param attributeElement to be serialized for the gsonExport; The object that needs to be converted to Json
+	 * @param type the actual type (fully genericized version) of the source object
+	 * @param context isn't used here
+	 * @return a JsonElement corresponding to the specified object
+	 */
 	@Override
 	public JsonElement serialize(EMFAttributeElement attributeElement, Type type, JsonSerializationContext context) {
 		final JsonObject jsonObject = new JsonObject();

--- a/plugins/org.but4reuse.adapters.emf/src/serialization/EMFAttributeElementSerializer.java
+++ b/plugins/org.but4reuse.adapters.emf/src/serialization/EMFAttributeElementSerializer.java
@@ -1,0 +1,33 @@
+package serialization;
+
+import java.lang.reflect.Type;
+
+import org.but4reuse.adapters.emf.EMFAttributeElement;
+import org.eclipse.emf.diffmerge.util.ModelImplUtil;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class EMFAttributeElementSerializer implements JsonSerializer<EMFAttributeElement> {
+
+	@Override
+	public JsonElement serialize(EMFAttributeElement attributeElement, Type type, JsonSerializationContext context) {
+		final JsonObject jsonObject = new JsonObject();
+		
+		final String ownerString = ModelImplUtil.getXMLID(attributeElement.owner);
+		final String nameString = attributeElement.eAttribute.getName();
+		final String valueString = attributeElement.value.toString();
+		
+		final JsonObject attributeJsonObject = new JsonObject();
+		
+		attributeJsonObject.addProperty("owner", ownerString == null ? "" : ownerString);
+		attributeJsonObject.addProperty("name", nameString == null ? "" : nameString);
+		attributeJsonObject.addProperty("value", valueString == null ? "" : valueString);
+		
+		jsonObject.add("attribute", attributeJsonObject);
+		
+		return jsonObject;
+	}
+}

--- a/plugins/org.but4reuse.adapters.emf/src/serialization/EMFClassElementSerializer.java
+++ b/plugins/org.but4reuse.adapters.emf/src/serialization/EMFClassElementSerializer.java
@@ -1,0 +1,31 @@
+package serialization;
+
+import java.lang.reflect.Type;
+
+import org.but4reuse.adapters.emf.EMFClassElement;
+import org.eclipse.emf.diffmerge.util.ModelImplUtil;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class EMFClassElementSerializer implements JsonSerializer<EMFClassElement> {
+
+	@Override
+	public JsonElement serialize(EMFClassElement classElement, Type type, JsonSerializationContext context) {
+		final JsonObject jsonObject = new JsonObject();
+		
+		final String ownerString = ModelImplUtil.getXMLID(classElement.owner);
+		final String eObjectString = ModelImplUtil.getXMLID(classElement.eObject);
+		
+		final JsonObject classJsonObject = new JsonObject();
+		
+		classJsonObject.addProperty("owner", ownerString == null ? "" : ownerString);
+		classJsonObject.addProperty("eObject", eObjectString == null ? "" : eObjectString);
+		
+		jsonObject.add("class", classJsonObject);
+		
+		return jsonObject;
+	}
+}

--- a/plugins/org.but4reuse.adapters.emf/src/serialization/EMFClassElementSerializer.java
+++ b/plugins/org.but4reuse.adapters.emf/src/serialization/EMFClassElementSerializer.java
@@ -10,8 +10,23 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+/**
+ * This is a serializer for the gson export of EMFClassElements to be registered as TypeAdapter on the GsonBuilder
+ */
 public class EMFClassElementSerializer implements JsonSerializer<EMFClassElement> {
 
+	/**
+	 * Gson invokes this call-back method during serialization when it encounters a field of the specified type.
+	 * In the implementation of this call-back method, you should consider invoking
+	 * JsonSerializationContext.serialize(Object, Type) method to create JsonElements for any non-trivial field
+	 * of the src object. However, you should never invoke it on the src object itself since that will cause
+	 * an infinite loop (Gson will call your call-back method again).
+	 *
+	 * @param classElement to be serialized for the gsonExport; The object that needs to be converted to Json
+	 * @param type the actual type (fully genericized version) of the source object
+	 * @param context isn't used here
+	 * @return a JsonElement corresponding to the specified object
+	 */
 	@Override
 	public JsonElement serialize(EMFClassElement classElement, Type type, JsonSerializationContext context) {
 		final JsonObject jsonObject = new JsonObject();

--- a/plugins/org.but4reuse.adapters.emf/src/serialization/EMFReferenceElementSerializer.java
+++ b/plugins/org.but4reuse.adapters.emf/src/serialization/EMFReferenceElementSerializer.java
@@ -13,8 +13,23 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+/**
+ * This is a serializer for the gson export of EMFReferenceElements to be registered as TypeAdapter on the GsonBuilder
+ */
 public class EMFReferenceElementSerializer implements JsonSerializer<EMFReferenceElement> {
 
+	/**
+	 * Gson invokes this call-back method during serialization when it encounters a field of the specified type.
+	 * In the implementation of this call-back method, you should consider invoking
+	 * JsonSerializationContext.serialize(Object, Type) method to create JsonElements for any non-trivial field
+	 * of the src object. However, you should never invoke it on the src object itself since that will cause
+	 * an infinite loop (Gson will call your call-back method again).
+	 *
+	 * @param referenceElement to be serialized for the gsonExport; The object that needs to be converted to Json
+	 * @param type the actual type (fully genericized version) of the source object
+	 * @param context isn't used here
+	 * @return a JsonElement corresponding to the specified object
+	 */
 	@Override
 	public JsonElement serialize(EMFReferenceElement referenceElement, Type type, JsonSerializationContext context) {
 		final JsonObject jsonObject = new JsonObject();

--- a/plugins/org.but4reuse.adapters.emf/src/serialization/EMFReferenceElementSerializer.java
+++ b/plugins/org.but4reuse.adapters.emf/src/serialization/EMFReferenceElementSerializer.java
@@ -1,0 +1,42 @@
+package serialization;
+
+import java.lang.reflect.Type;
+
+import org.but4reuse.adapters.emf.EMFReferenceElement;
+import org.eclipse.emf.diffmerge.util.ModelImplUtil;
+import org.eclipse.emf.ecore.EObject;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class EMFReferenceElementSerializer implements JsonSerializer<EMFReferenceElement> {
+
+	@Override
+	public JsonElement serialize(EMFReferenceElement referenceElement, Type type, JsonSerializationContext context) {
+		final JsonObject jsonObject = new JsonObject();
+		
+		
+		final JsonObject referenceJsonObject = new JsonObject();
+		
+		referenceJsonObject.addProperty("owner", ModelImplUtil.getXMLID(referenceElement.owner));
+		referenceJsonObject.addProperty("name", referenceElement.eReference.getName());
+		
+		final JsonArray referenced = new JsonArray();
+		
+		for(final EObject reference : referenceElement.referenced) {
+			final String r = ModelImplUtil.getXMLID(reference);
+			final JsonPrimitive primitive = new JsonPrimitive(r == null ? "" : r);
+			referenced.add(primitive);
+		}
+		
+		referenceJsonObject.add("referenced", referenced);
+		
+		jsonObject.add("reference", referenceJsonObject);
+		
+		return jsonObject;
+	}
+}

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
@@ -69,19 +69,9 @@ public class FCABlockIdentification implements IBlockIdentification {
 				}
 
 				IElement e = (IElement) ew.getElement();
-				List<ElementWrapper> ews = eewmap.get(e);
-				if (ews == null) {
-					ews = new ArrayList<ElementWrapper>();
-				}
-				ews.add(ew);
-				eewmap.put(e, ews);
+				eewmap.computeIfAbsent(e, k -> new ArrayList<ElementWrapper>()).add(ew);
 
-				List<Integer> artefactIndexes = R.get(e);
-				if (artefactIndexes == null) {
-					artefactIndexes = new ArrayList<Integer>();
-				}
-				artefactIndexes.add(i);
-				R.put(e, artefactIndexes);
+				R.computeIfAbsent(e, k -> new ArrayList<Integer>()).add(i);
 			}
 		}
 

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
@@ -16,6 +16,7 @@ import org.but4reuse.adapters.IElement;
 import org.but4reuse.block.identification.IBlockIdentification;
 import org.but4reuse.fca.utils.FCAUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.common.util.EList;
 
 import fr.labri.galatea.Attribute;
 import fr.labri.galatea.BinaryAttribute;
@@ -57,7 +58,10 @@ public class FCABlockIdentification implements IBlockIdentification {
 
 			monitor.subTask("Block Creation. Preparation step " + (i + 1) + "/" + adaptedArtefacts.size());
 			AdaptedArtefact currentList = adaptedArtefacts.get(i);
-			for (ElementWrapper ew : currentList.getOwnedElementWrappers()) {
+			EList<ElementWrapper> ownedElementWrappers = currentList.getOwnedElementWrappers();
+			for(int j = 0; j < ownedElementWrappers.size(); ++j) {
+				ElementWrapper ew = ownedElementWrappers.get(j);
+				monitor.subTask("Block Creation. Preparation step " + (i + 1) + "/" + adaptedArtefacts.size() + " " + (j + 1) + "/" + ownedElementWrappers.size());
 
 				// user cancel
 				if (monitor.isCanceled()) {

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
@@ -126,25 +126,9 @@ public class FCABlockIdentification implements IBlockIdentification {
 		}
 
 		monitor.subTask("Block Creation. Sorting blocks by frequency.");
-		blocks = reorderBlocksByFrequency(R, blocks);
+		blocks.sort((b0, b1) -> b1.getOwnedBlockElements().get(0).getElementWrappers().size() - b0.getOwnedBlockElements().get(0).getElementWrappers().size());
 
 		// finished
 		return blocks;
 	}
-
-	// insertion sort
-	private List<Block> reorderBlocksByFrequency(LinkedHashMap<IElement, List<Integer>> R, List<Block> blocks) {
-		Block temp;
-		for (int i = 1; i < blocks.size(); i++) {
-			for (int j = i; j > 0; j--) {
-				if(blocks.get(j).getOwnedBlockElements().get(0).getElementWrappers().size() > blocks.get(j-1).getOwnedBlockElements().get(0).getElementWrappers().size()){
-					temp = blocks.get(j);
-					blocks.set(j, blocks.get(j - 1));
-					blocks.set(j - 1, temp);
-				}
-			}
-		}
-		return blocks;
-	}
-
 }

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
@@ -94,13 +94,19 @@ public class FCABlockIdentification implements IBlockIdentification {
 				fc.addPair(fc.getEntity("Artefact " + ia), attr);
 			}
 			R.remove(e);
+			monitor.subTask("Block Creation. Creating Blocks. Creating Formal Context." + R.size());
 		}
 
+		monitor.subTask("Block Creation. Creating concept lattice.");
 		// Generate concept lattice
 		ConceptOrder cl = FCAUtils.createConceptLattice(fc);
 		
 		// Add a block for each non empty concept
+		int i = 0;
+		final Set<Concept> concepts = cl.getConcepts();
+		final int is = concepts.size();
 		for (Concept c : cl.getConcepts()) {
+			monitor.subTask("Block Creation. Creating Blocks." + " " + ++i + "/" + is);
 			// getIntent returns also the intent of the parents, we are only
 			// interested in the getSimplifiedIntent which is the one that only
 			// belongs to this concept
@@ -119,6 +125,7 @@ public class FCABlockIdentification implements IBlockIdentification {
 			}
 		}
 
+		monitor.subTask("Block Creation. Sorting blocks by frequency.");
 		blocks = reorderBlocksByFrequency(R, blocks);
 
 		// finished

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/constraints/discovery/FCAConstraintsDiscovery.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/constraints/discovery/FCAConstraintsDiscovery.java
@@ -63,10 +63,10 @@ public class FCAConstraintsDiscovery implements IConstraintsDiscovery {
 							constraint.addExplanation("Concept lattice found");
 							constraintList.add(constraint);
 						}
+						++j;
 					}
-					++j;
+					++k;
 				}
-				++k;
 			}
 			++i;
 		}

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/constraints/discovery/FCAConstraintsDiscovery.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/constraints/discovery/FCAConstraintsDiscovery.java
@@ -37,13 +37,23 @@ public class FCAConstraintsDiscovery implements IConstraintsDiscovery {
 
 		// REQUIRES
 		monitor.subTask("FCA: Checking Requires relations");
-		for (Concept c : cl.getConcepts()) {
+		final Set<Concept> concepts = cl.getConcepts();
+		int i = 0;
+		final int si = concepts.size();
+		for (Concept c : concepts) {
+			monitor.subTask("FCA: Check Requires relations. Concept " + i + "/" + si);
 			// getIntent returns also the intent of the parents,
 			// getSimplifiedIntent which is the one that only belongs to this
 			// concept
 			if (!c.getSimplifiedIntent().isEmpty()) {
-				for (Attribute owner : c.getSimplifiedIntent()) {
-					for (Attribute a : c.getIntent()) {
+				final Set<Attribute> simplifiedIntent = c.getSimplifiedIntent();
+				int k = 0;
+				for (Attribute owner : simplifiedIntent) {
+					monitor.subTask("FCA: Check Requires relations. Concept " + i + "/" + si +". Attribute " + k + "/" + simplifiedIntent.size());
+					final Set<Attribute> intent = c.getIntent();
+					int j = 0;
+					for (Attribute a : intent) {
+						monitor.subTask("FCA: Check Requires relations. Concept " + i + "/" + si+". Attribute " + k + "/" + simplifiedIntent.size() +". Attribute " + j + "/" + intent.size());
 						if (!owner.equals(a)) {
 							// if (!owner.sameAs(a)) {
 							// add constraint
@@ -54,8 +64,11 @@ public class FCAConstraintsDiscovery implements IConstraintsDiscovery {
 							constraintList.add(constraint);
 						}
 					}
+					++j;
 				}
+				++k;
 			}
+			++i;
 		}
 
 		// EXCLUDES

--- a/plugins/org.but4reuse.feature.identification.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.but4reuse.feature.identification.ui/META-INF/MANIFEST.MF
@@ -13,7 +13,11 @@ Require-Bundle: org.eclipse.ui,
  org.but4reuse.block.identification,
  org.but4reuse.feature.constraints,
  org.but4reuse.utils,
- org.eclipse.core.resources
+ org.eclipse.core.resources,
+ com.google.gson;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: BUT4Reuse
+Import-Package: org.but4reuse.adapters.emf,
+ org.eclipse.emf.diffmerge.util,
+ serialization

--- a/plugins/org.but4reuse.feature.identification.ui/src/org/but4reuse/feature/identification/ui/actions/FeatureIdentificationAction.java
+++ b/plugins/org.but4reuse.feature.identification.ui/src/org/but4reuse/feature/identification/ui/actions/FeatureIdentificationAction.java
@@ -142,49 +142,7 @@ public class FeatureIdentificationAction implements IObjectActionDelegate, IView
 								adaptedModel.getOwnedBlocks().addAll(blocks);
 								monitor.worked(1);
 
-								Gson gson = new GsonBuilder()
-										.registerTypeAdapter(EMFClassElement.class, new EMFClassElementSerializer())
-										.registerTypeAdapter(EMFAttributeElement.class, new EMFAttributeElementSerializer())
-										.registerTypeAdapter(EMFReferenceElement.class, new EMFReferenceElementSerializer())
-										.setPrettyPrinting().create();
-
-
-								for(int i = 0; i < blocks.size(); ++i) {
-									final Block block = blocks.get(i);
-
-									try {
-										// replace with individual user?
-										final JsonWriter jsonWriter = gson.newJsonWriter(
-												new BufferedWriter(
-														new FileWriter(new File(String.format("C:\\Users\\mauri\\Desktop\\test_models\\feature_elements\\feature_elements_%d.json", i)))));
-
-										final JsonObject jsonObject = new JsonObject();
-
-										final JsonArray elementsArray = new JsonArray();
-
-										for(final BlockElement blockElement : block.getOwnedBlockElements()) {
-											final IElement element = (IElement) blockElement.getElementWrappers().get(0).getElement();
-
-											if(element instanceof EMFClassElement) {
-												elementsArray.add(gson.toJsonTree(element, EMFClassElement.class));
-											}
-											else if (element instanceof EMFAttributeElement) {
-												elementsArray.add(gson.toJsonTree(element, EMFAttributeElement.class));
-											}
-											else if (element instanceof EMFReferenceElement) {
-												elementsArray.add(gson.toJsonTree(element, EMFReferenceElement.class));
-											}
-											else {
-												System.out.println("Unknown element type!");
-											}
-										}
-
-										jsonObject.add("elements", elementsArray);
-										gson.toJson(jsonObject, jsonWriter);
-										jsonWriter.flush();
-									} catch (IOException | SecurityException e) {
-									}
-								}
+								gsonExport(blocks);
 
 								monitor.subTask("Constraints discovery");
 								List<IConstraintsDiscovery> constraintsDiscoveryAlgorithms = ConstraintsDiscoveryHelper
@@ -236,6 +194,52 @@ public class FeatureIdentificationAction implements IObjectActionDelegate, IView
 					}
 				}
 
+			}
+		}
+	}
+
+	private static void gsonExport(List<Block> blocks) {
+		Gson gson = new GsonBuilder()
+				.registerTypeAdapter(EMFClassElement.class, new EMFClassElementSerializer())
+				.registerTypeAdapter(EMFAttributeElement.class, new EMFAttributeElementSerializer())
+				.registerTypeAdapter(EMFReferenceElement.class, new EMFReferenceElementSerializer())
+				.setPrettyPrinting().create();
+
+
+		for(int i = 0; i < blocks.size(); ++i) {
+			final Block block = blocks.get(i);
+
+			try {
+				// replace with individual user?
+				final JsonWriter jsonWriter = gson.newJsonWriter(
+						new BufferedWriter(
+								new FileWriter(new File(String.format("C:\\Users\\mauri\\Desktop\\test_models\\feature_elements\\feature_elements_%d.json", i)))));
+
+				final JsonObject jsonObject = new JsonObject();
+
+				final JsonArray elementsArray = new JsonArray();
+
+				for(final BlockElement blockElement : block.getOwnedBlockElements()) {
+					final IElement element = (IElement) blockElement.getElementWrappers().get(0).getElement();
+
+					if(element instanceof EMFClassElement) {
+						elementsArray.add(gson.toJsonTree(element, EMFClassElement.class));
+					}
+					else if (element instanceof EMFAttributeElement) {
+						elementsArray.add(gson.toJsonTree(element, EMFAttributeElement.class));
+					}
+					else if (element instanceof EMFReferenceElement) {
+						elementsArray.add(gson.toJsonTree(element, EMFReferenceElement.class));
+					}
+					else {
+						System.out.println("Unknown element type!");
+					}
+				}
+
+				jsonObject.add("elements", elementsArray);
+				gson.toJson(jsonObject, jsonWriter);
+				jsonWriter.flush();
+			} catch (IOException | SecurityException e) {
 			}
 		}
 	}

--- a/plugins/org.but4reuse.feature.identification.ui/src/org/but4reuse/feature/identification/ui/actions/FeatureIdentificationAction.java
+++ b/plugins/org.but4reuse.feature.identification.ui/src/org/but4reuse/feature/identification/ui/actions/FeatureIdentificationAction.java
@@ -6,6 +6,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,8 +33,10 @@ import org.but4reuse.feature.constraints.IConstraintsDiscovery;
 import org.but4reuse.feature.constraints.helper.ConstraintsDiscoveryHelper;
 import org.but4reuse.feature.constraints.impl.ConstraintsHelper;
 import org.but4reuse.utils.emf.EMFUtils;
+import org.but4reuse.utils.files.FileUtils;
 import org.but4reuse.utils.workbench.WorkbenchUtils;
 import org.but4reuse.visualisation.helpers.VisualisationsHelper;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.action.IAction;
@@ -210,10 +213,15 @@ public class FeatureIdentificationAction implements IObjectActionDelegate, IView
 			final Block block = blocks.get(i);
 
 			try {
-				// replace with individual user?
+				// Get default construction uri
+				String out = "/projectName";
+				IContainer output = AdaptedModelManager.getDefaultOutput();
+				if (output != null) {
+					out = output.getFullPath().toString();
+				}
 				final JsonWriter jsonWriter = gson.newJsonWriter(
 						new BufferedWriter(
-								new FileWriter(new File(String.format("C:\\Users\\mauri\\Desktop\\test_models\\feature_elements\\feature_elements_%d.json", i)))));
+								new FileWriter(FileUtils.getFile(new URI(String.format("platform:/resource" + out + "/featureElements/feature_elements_%d.json", i))))));
 
 				final JsonObject jsonObject = new JsonObject();
 
@@ -239,7 +247,8 @@ public class FeatureIdentificationAction implements IObjectActionDelegate, IView
 				jsonObject.add("elements", elementsArray);
 				gson.toJson(jsonObject, jsonWriter);
 				jsonWriter.flush();
-			} catch (IOException | SecurityException e) {
+			} catch (IOException | SecurityException | URISyntaxException e) {
+				e.printStackTrace();
 			}
 		}
 	}

--- a/plugins/org.but4reuse.feature.identification.ui/src/org/but4reuse/feature/identification/ui/actions/FeatureIdentificationAction.java
+++ b/plugins/org.but4reuse.feature.identification.ui/src/org/but4reuse/feature/identification/ui/actions/FeatureIdentificationAction.java
@@ -201,6 +201,13 @@ public class FeatureIdentificationAction implements IObjectActionDelegate, IView
 		}
 	}
 
+	/**
+	 * Export the set of identified blocks into the folder featureElements
+	 * (has to be located in the same directory as e.g. featureModels), if present.
+	 * Create a separate gson-file for each block containing its atomic modelling elements (AMEs).
+	 *
+	 * @param blocks identified in the FeatureIdentification
+	 */
 	private static void gsonExport(List<Block> blocks) {
 		Gson gson = new GsonBuilder()
 				.registerTypeAdapter(EMFClassElement.class, new EMFClassElementSerializer())

--- a/plugins/org.but4reuse.featuremodel.synthesis/plugin.xml
+++ b/plugins/org.but4reuse.featuremodel.synthesis/plugin.xml
@@ -72,5 +72,10 @@
             description="Create alternative groups with the excludes constraints and then the hierarchy with the requires constraints"
             name="Alternatives Before Hierarchy">
       </fmsynthesis>
+      <fmsynthesis
+            class="org.but4reuse.featuremodel.synthesis.impl.AlternativesBeforeHierarchyOptimizedFMSynthesis"
+            description="Create alternative groups with the excludes constraints and then the hierarchy with the requires constraints. (Optimized)"
+            name="Alternatives Before Hierarchy (Optimized)">
+      </fmsynthesis>
    </extension>
 </plugin>

--- a/plugins/org.but4reuse.featuremodel.synthesis/src/org/but4reuse/featuremodel/synthesis/impl/AlternativesBeforeHierarchyFMSynthesis.java
+++ b/plugins/org.but4reuse.featuremodel.synthesis/src/org/but4reuse/featuremodel/synthesis/impl/AlternativesBeforeHierarchyFMSynthesis.java
@@ -42,6 +42,7 @@ public class AlternativesBeforeHierarchyFMSynthesis implements IFeatureModelSynt
 
 	@Override
 	public void createFeatureModel(URI outputContainer, IProgressMonitor monitor) {
+		System.out.println("Creating Feature Model.");
 		AdaptedModel adaptedModel = AdaptedModelManager.getAdaptedModel();
 		// TODO Check for loops in the Requires graph.
 		// Assumption is that there are no loops in the Requires constraints
@@ -73,6 +74,7 @@ public class AlternativesBeforeHierarchyFMSynthesis implements IFeatureModelSynt
 		// Common blocks (probably mandatory)
 		List<Block> common = AdaptedModelHelper.getCommonBlocks(adaptedModel);
 
+		System.out.println("Creating Feature Model. Adding Blocks.");
 		// Add blocks as features
 		for (Block block : adaptedModel.getOwnedBlocks()) {
 			Feature f = new Feature(fm, FeatureIDEUtils.validFeatureName(block.getName()));
@@ -86,15 +88,21 @@ public class AlternativesBeforeHierarchyFMSynthesis implements IFeatureModelSynt
 			fmFeatures.add(f);
 		}
 
+		System.out.println("Creating Feature Model. Adding Constraints.");
 		// Add constraints
 		for (IConstraint constraint : ConstraintsHelper.getCalculatedConstraints(adaptedModel)) {
 			FeatureIDEUtils.addConstraint(fm, FeatureIDEUtils.getConstraintString(constraint));
 		}
 
+		System.out.println("Creating Feature Model. Identifying Alt Groups.");
 		// Identify alt groups
 		AltGroupList altGroupList = new AltGroupList();
 		List<IConstraint> constraints = ConstraintsHelper.getCalculatedConstraints(adaptedModel);
+		int i = 0;
+		int si = constraints.size();
 		for (IConstraint constraint : constraints) {
+			System.out.println("Creating Feature Model. Identifying Alt Groups. Constraints Loop " + i + "/" + si);
+			++i;
 			if (constraint instanceof BasicExcludesConstraint) {
 				BasicExcludesConstraint c = (BasicExcludesConstraint)constraint;
 				IFeature feature1 = fm.getFeature(FeatureIDEUtils.validFeatureName(c.getBlock1().getName()));
@@ -140,6 +148,8 @@ public class AlternativesBeforeHierarchyFMSynthesis implements IFeatureModelSynt
 			}
 		}
 
+		System.out.println("Creating Feature Model. Create alt groups in the fm.");
+
 		// Create alt groups in the fm
 		for (AltGroup altGroup : altGroupList.altGroups) {
 			IFeature fakeAltFeature = new Feature(fm, "Alternative_" + altGroup.id);
@@ -153,9 +163,14 @@ public class AlternativesBeforeHierarchyFMSynthesis implements IFeatureModelSynt
 			fmFeatures.add(fakeAltFeature);
 		}
 
-		// Create hierarchy with the Requires
-		for (IFeature f : fmFeatures) {
+		System.out.println("Creating Feature Model. Create hierarchy with the Requires.");
 
+		// Create hierarchy with the Requires
+		i = 0;
+		si = fmFeatures.size();
+		for (IFeature f : fmFeatures) {
+			System.out.println("Creating Feature Model. Create hierarchy with the Requires. Looping Features " + i + "/" + si);
+			++i;
 			// check if the feature belongs to an alternative group
 			AltGroup altGroup = altGroupList.getAltGroupOfFeature(f);
 

--- a/plugins/org.but4reuse.featuremodel.synthesis/src/org/but4reuse/featuremodel/synthesis/impl/AlternativesBeforeHierarchyOptimizedFMSynthesis.java
+++ b/plugins/org.but4reuse.featuremodel.synthesis/src/org/but4reuse/featuremodel/synthesis/impl/AlternativesBeforeHierarchyOptimizedFMSynthesis.java
@@ -345,7 +345,7 @@ public class AlternativesBeforeHierarchyOptimizedFMSynthesis implements IFeature
 	 * @param f2 The name of IFeature f2 (s. FeatureIDEUtils.java)
 	 * @param requiredFeatures is a map, that replaces getFeatureRequiredFeatures (s. FeatureIDEUtils.java).
 	 *                         It could be analogously called getFeatureNameRequiredFeatureName, but that's too long...
-	 * @return
+	 * @return if (f2 requires directly or transitively f1) then true else false
 	 */
 	public static boolean isAncestorFeature1ofFeature2(FeatureModel fm, String f1,
 													   String f2, Map<String, List<String>> requiredFeatures) {

--- a/plugins/org.but4reuse.featuremodel.synthesis/src/org/but4reuse/featuremodel/synthesis/impl/AlternativesBeforeHierarchyOptimizedFMSynthesis.java
+++ b/plugins/org.but4reuse.featuremodel.synthesis/src/org/but4reuse/featuremodel/synthesis/impl/AlternativesBeforeHierarchyOptimizedFMSynthesis.java
@@ -1,0 +1,383 @@
+package org.but4reuse.featuremodel.synthesis.impl;
+
+import de.ovgu.featureide.fm.core.base.FeatureUtils;
+import de.ovgu.featureide.fm.core.base.IFeature;
+import de.ovgu.featureide.fm.core.base.impl.DefaultFeatureModelFactory;
+import de.ovgu.featureide.fm.core.base.impl.Feature;
+import de.ovgu.featureide.fm.core.base.impl.FeatureModel;
+import org.but4reuse.adaptedmodel.AdaptedModel;
+import org.but4reuse.adaptedmodel.Block;
+import org.but4reuse.adaptedmodel.helpers.AdaptedModelHelper;
+import org.but4reuse.adaptedmodel.manager.AdaptedModelManager;
+import org.but4reuse.feature.constraints.BasicExcludesConstraint;
+import org.but4reuse.feature.constraints.IConstraint;
+import org.but4reuse.feature.constraints.impl.ConstraintsHelper;
+import org.but4reuse.featuremodel.synthesis.IFeatureModelSynthesis;
+import org.but4reuse.featuremodel.synthesis.utils.FeatureIDEUtils;
+import org.but4reuse.utils.files.FileUtils;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import java.io.File;
+import java.net.URI;
+import java.util.*;
+
+/**
+ *  This is the optimized HashSet-variant written by Lukas Selvaggio.
+ *
+ * Feature Model synthesis: First we identify alternative groups, then we create
+ * the hierarchy. From the possible parent candidates, we discard those that are
+ * already containing other parent candidates. The parent candidates of an
+ * alternative group are the intersection of the parent candidates of the
+ * features integrating the group. In case of several parent candidates, we
+ * select parent candidates belonging to alternative groups and in the case of
+ * any, we select the parent candidate with the higher number of reasons in the
+ * requires constraint description. Finally, the features without parent are
+ * added to the root. The common features are set as mandatory and redundant
+ * constraints are removed.
+ *
+ * @author jabier.martinez
+ */
+public class AlternativesBeforeHierarchyOptimizedFMSynthesis implements IFeatureModelSynthesis {
+
+	@Override
+	public void createFeatureModel(URI outputContainer, IProgressMonitor monitor) {
+		System.out.print("Time 1 = " + System.currentTimeMillis());
+		System.out.println("Creating Feature Model.");
+		AdaptedModel adaptedModel = AdaptedModelManager.getAdaptedModel();
+		// TODO Check for loops in the Requires graph.
+		// Assumption is that there are no loops in the Requires constraints
+		// between blocks as it happens with the default block identification
+		// algorithm.
+		FeatureModel fm = new FeatureModel(DefaultFeatureModelFactory.ID);
+		// fm.getFeatures returns a collection with random ordering...
+		// let's keep our own list of features
+		List<IFeature> fmFeatures = new ArrayList<IFeature>();
+
+		String rootName = AdaptedModelHelper.getName(adaptedModel);
+		if (rootName == null) {
+			rootName = "FeatureModel";
+		} else {
+			rootName = FeatureIDEUtils.validFeatureName(rootName);
+		}
+		IFeature root = new Feature(fm, rootName);
+
+		FeatureUtils.setAnd(root, true);
+
+		Set<String> parentAssigned = new HashSet<>();
+
+		FeatureUtils.setRoot(fm, root);
+		FeatureUtils.addFeature(fm, root);
+
+		fm.addFeature(root);
+		fmFeatures.add(root);
+
+		// Common blocks (probably mandatory)
+		List<Block> common = AdaptedModelHelper.getCommonBlocks(adaptedModel);
+
+		System.out.println("Creating Feature Model. Adding Blocks.");
+		// Add blocks as features
+		for (Block block : adaptedModel.getOwnedBlocks()) {
+			Feature f = new Feature(fm, FeatureIDEUtils.validFeatureName(block.getName()));
+			FeatureUtils.setAbstract(f, false);
+			if (common.contains(block)) {
+				FeatureUtils.setMandatory(f, true);
+			} else {
+				FeatureUtils.setMandatory(f, false);
+			}
+			fm.addFeature(f);
+			fmFeatures.add(f);
+		}
+
+		System.out.println("Creating Feature Model. Adding Constraints.");
+		// Add constraints
+		for (IConstraint constraint : ConstraintsHelper.getCalculatedConstraints(adaptedModel)) {
+			FeatureIDEUtils.addConstraint(fm, FeatureIDEUtils.getConstraintString(constraint));
+		}
+
+		System.out.println("Creating Feature Model. Identifying Alt Groups.");
+		// Identify alt groups
+		AltGroupList altGroupList = new AltGroupList();
+		List<IConstraint> constraints = ConstraintsHelper.getCalculatedConstraints(adaptedModel);
+		int i = 0;
+		int si = constraints.size();
+		for (IConstraint constraint : constraints) {
+			System.out.println("Creating Feature Model. Identifying Alt Groups. Constraints Loop " + i + "/" + si);
+			++i;
+			if (constraint instanceof BasicExcludesConstraint) {
+				BasicExcludesConstraint c = (BasicExcludesConstraint)constraint;
+				IFeature feature1 = fm.getFeature(FeatureIDEUtils.validFeatureName(c.getBlock1().getName()));
+				IFeature feature2 = fm.getFeature(FeatureIDEUtils.validFeatureName(c.getBlock2().getName()));
+				// any of them exists in previous?
+				AltGroup altF1 = altGroupList.getAltGroupOfFeature(feature1);
+				AltGroup altF2 = altGroupList.getAltGroupOfFeature(feature2);
+				// Completely new alt group
+				if (altF1 == null && altF2 == null) {
+					altGroupList.addAltGroup(feature1, feature2);
+				}
+				// feature2 already was in a alt group so check if for all the
+				// features of this alt group feature1 is also excluded
+				else if (altF1 == null) {
+					boolean allFound = true;
+					for (IFeature f : altF2.features) {
+						if (!f.equals(feature2)) {
+							if (!FeatureIDEUtils.existsExcludeConstraint(constraints, f, feature1)) {
+								allFound = false;
+								break;
+							}
+						}
+					}
+					if (allFound) {
+						altF2.features.add(feature1);
+					}
+				}
+				// feature1 already was in an alt group
+				else if (altF2 == null) {
+					boolean allFound = true;
+					for (IFeature f : altF1.features) {
+						if (!f.equals(feature1)) {
+							if (!FeatureIDEUtils.existsExcludeConstraint(constraints, f, feature2)) {
+								allFound = false;
+								break;
+							}
+						}
+					}
+					if (allFound) {
+						altF1.features.add(feature2);
+					}
+				}
+			}
+		}
+
+		System.out.println("Creating Feature Model. Create alt groups in the fm.");
+
+		// Create alt groups in the fm
+		for (AltGroup altGroup : altGroupList.altGroups) {
+			IFeature fakeAltFeature = new Feature(fm, "Alternative_" + altGroup.id);
+			altGroup.altRoot = fakeAltFeature;
+			FeatureUtils.setAlternative(fakeAltFeature);
+			FeatureUtils.setAbstract(fakeAltFeature, true);
+			FeatureUtils.setMandatory(fakeAltFeature, false);
+			FeatureUtils.setChildren(fakeAltFeature, altGroup.features);
+			FeatureUtils.addFeature(fm, fakeAltFeature);
+			fm.addFeature(fakeAltFeature);
+			fmFeatures.add(fakeAltFeature);
+		}
+
+		System.out.println("Creating Feature Model. Create hierarchy with the Requires.");
+
+		Map<String, List<String>> requiredFeaturesMap = new HashMap<>();
+		Map<String, AltGroup> altGroupsMap = new HashMap<>();
+		Map<String, Map<String, Boolean>> isAncestorMap = new HashMap<>();
+
+		i = 0;
+		for(final IFeature feature : fmFeatures) {
+			System.out.println("Creating Feature Model. Prepare Loop 1 | " + i + "/" + fmFeatures.size());
+			++i;
+			final String name = feature.getName();
+			if(requiredFeaturesMap.containsKey(name)) {
+				System.out.println("Something went wrong 1");
+			}
+			else {
+				final List<IFeature> requiredFeatures = FeatureIDEUtils.getFeatureRequiredFeatures(fm, constraints, feature);
+				final List<String> names = new ArrayList<>();
+				for(final IFeature requiredFeature : requiredFeatures) {
+					names.add(requiredFeature.getName());
+				}
+				requiredFeaturesMap.put(name, names);
+			}
+			if(altGroupsMap.containsKey(name)) {
+				System.out.println("Something went wrong 2");
+			}
+
+			else {
+				altGroupsMap.put(name, altGroupList.getAltGroupOfFeature(feature));
+			}
+		}
+
+		i = 0;
+		for(final IFeature feature : fmFeatures) {
+			System.out.println("Creating Feature Model. Prepare Loop 2 | " + i + "/" + fmFeatures.size());
+			++i;
+			final String name = feature.getName();
+			if(isAncestorMap.containsKey(name)) {
+				System.out.println("Something went wrong 3");
+			}
+			else {
+				final Map<String, Boolean> isAncestor = new HashMap<>();
+				for(final IFeature feature2 : fmFeatures) {
+					final String name2 = feature2.getName();
+					if(isAncestor.containsKey(name2)) {
+						System.out.println("Something went wrong 4");
+					}
+					else {
+						isAncestor.put(name2, isAncestorFeature1ofFeature2(fm, name, name2, requiredFeaturesMap));
+					}
+				}
+				isAncestorMap.put(name, isAncestor);
+			}
+		}
+
+		// Create hierarchy with the Requires
+		i = 0;
+		si = fmFeatures.size();
+		for (IFeature f : fmFeatures) {
+			System.out.println("Creating Feature Model. Create hierarchy with the Requires. Looping Features " + i + "/" + si);
+			++i;
+			// check if the feature belongs to an alternative group
+			AltGroup altGroup = altGroupsMap.get(f.getName());
+
+			List<String> parentCandidates;
+			if (altGroup == null) {
+				// normal feature
+				parentCandidates = requiredFeaturesMap.get(f.getName());
+			} else {
+				// feature inside an alt group
+				// the parent candidates will be those that are shared parent
+				// candidates for all the alt group
+				parentCandidates = requiredFeaturesMap.get(f.getName());
+				for (IFeature altf : altGroup.features) {
+					parentCandidates.retainAll(requiredFeaturesMap.get(altf.getName()));
+				}
+			}
+			List<IFeature> definitiveList = new ArrayList<IFeature>();
+			for (String s : parentCandidates) {
+				definitiveList.add(fm.getFeature(s));
+			}
+
+			// Reduce the parent candidates, remove ancestors
+			for (String s1 : parentCandidates) {
+				final IFeature pc1 = fm.getFeature(s1);
+				for (String s2 : parentCandidates) {
+					final IFeature pc2 = fm.getFeature(s2);
+					if (pc1 != pc2) {
+						if (isAncestorMap.get(s1).get(s2)) {
+							definitiveList.remove(pc1);
+						} else if (isAncestorMap.get(s2).get(s1)) {
+							definitiveList.remove(pc2);
+						}
+					}
+				}
+			}
+
+			// Select one
+			if (!definitiveList.isEmpty()) {
+				IFeature parent = null;
+
+				// Preference to parents in alternative groups
+				// TODO for the moment get the first alternative group
+				for (IFeature dp : definitiveList) {
+					if (altGroupsMap.get(dp.getName()) != null) {
+						parent = dp;
+						break;
+					}
+				}
+
+				// If no parent in alternative group
+				// Get the one with higher number of reasons in the requires
+				// constraint
+				if (parent == null) {
+					int maximumReasons = Integer.MIN_VALUE;
+					for (IFeature dp : definitiveList) {
+						int reasons = FeatureIDEUtils.getNumberOfReasonsOfRequiresConstraint(constraints, f, dp);
+						if (reasons > maximumReasons) {
+							parent = dp;
+						}
+					}
+				}
+
+				// And add it
+				FeatureUtils.setAnd(parent, true);
+				if (altGroup == null) {
+					FeatureUtils.addChild(parent, f);
+					FeatureUtils.setParent(f, parent);
+					parentAssigned.add(f.getName());
+				} else {
+					// Only once for the whole alt group
+					if (!parentAssigned.contains(altGroup.altRoot.getName())) {
+						FeatureUtils.addChild(parent, altGroup.altRoot);
+						parentAssigned.add(altGroup.altRoot.getName());
+						FeatureUtils.setParent(altGroup.altRoot, parent);
+					}
+				}
+			}
+		}
+
+		// Features without parent are added to the root
+		LinkedList<IFeature> toTheRoot = new LinkedList<IFeature>();
+		for (IFeature f : fmFeatures) {
+			if (!f.equals(root)) {
+				AltGroup altGroup = altGroupsMap.get(f.getName());
+				if (altGroup != null) {
+					f = altGroup.altRoot;
+				}
+				if (!parentAssigned.contains(f.getName())) {
+					toTheRoot.add(f);
+					FeatureUtils.setParent(f, root);
+					FeatureUtils.addChild(root, f);
+					parentAssigned.add(f.getName());
+				}
+			}
+		}
+		FeatureUtils.setChildren(root, toTheRoot);
+
+		// Remove redundant constraints
+		FeatureIDEUtils.removeRedundantConstraints(fm);
+
+		// Save
+		try {
+			URI fmURI = new URI(outputContainer + this.getClass().getSimpleName() + ".xml");
+			File fmFile = FileUtils.getFile(fmURI);
+			FileUtils.createFile(fmFile);
+			FeatureIDEUtils.save(fm, fmFile);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		System.out.print("Time 1 = " + System.currentTimeMillis());
+	}
+
+	public static boolean isAncestorFeature1ofFeature2(FeatureModel fm, String f1,
+													   String f2, Map<String, List<String>> requiredFeatures) {
+		final List<String> directRequired = requiredFeatures.get(f2);
+		if (directRequired.contains(f1)) {
+			return true;
+		}
+		for (final String direct : directRequired) {
+			if (isAncestorFeature1ofFeature2(fm, f1, direct, requiredFeatures)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Auxiliary classes
+	 */
+	public class AltGroup {
+		LinkedList<IFeature> features = new LinkedList<IFeature>();
+		int id;
+		IFeature altRoot;
+	}
+
+	public class AltGroupList {
+		List<AltGroup> altGroups = new ArrayList<AltGroup>();
+
+		public AltGroup getAltGroupOfFeature(IFeature feature) {
+			for (AltGroup altGroup : altGroups) {
+				if (altGroup.features.contains(feature)) {
+					return altGroup;
+				}
+			}
+			return null;
+		}
+
+		public void addAltGroup(IFeature... features) {
+			AltGroup altGroup = new AltGroup();
+			// Automatically set the id
+			altGroup.id = altGroups.size() + 1;
+			for (IFeature feature : features) {
+				altGroup.features.add(feature);
+			}
+			altGroups.add(altGroup);
+		}
+	}
+}

--- a/plugins/org.but4reuse.featuremodel.synthesis/src/org/but4reuse/featuremodel/synthesis/impl/AlternativesBeforeHierarchyOptimizedFMSynthesis.java
+++ b/plugins/org.but4reuse.featuremodel.synthesis/src/org/but4reuse/featuremodel/synthesis/impl/AlternativesBeforeHierarchyOptimizedFMSynthesis.java
@@ -335,6 +335,18 @@ public class AlternativesBeforeHierarchyOptimizedFMSynthesis implements IFeature
 		System.out.print("Time 1 = " + System.currentTimeMillis());
 	}
 
+	/**
+	 * For example 3 requires 2 (3 is child of 2). Then 2 requires 1.
+	 * isAncestor 1 of 3 is true.
+	 * (s. isAncestorFeature1ofFeature2 in FeatureIDEUtils.java)
+	 *
+	 * @param fm exactly the same as in FeatureIDEUtils.java
+	 * @param f1 The name of IFeature f1 (s. FeatureIDEUtils.java)
+	 * @param f2 The name of IFeature f2 (s. FeatureIDEUtils.java)
+	 * @param requiredFeatures is a map, that replaces getFeatureRequiredFeatures (s. FeatureIDEUtils.java).
+	 *                         It could be analogously called getFeatureNameRequiredFeatureName, but that's too long...
+	 * @return
+	 */
 	public static boolean isAncestorFeature1ofFeature2(FeatureModel fm, String f1,
 													   String f2, Map<String, List<String>> requiredFeatures) {
 		final List<String> directRequired = requiredFeatures.get(f2);


### PR DESCRIPTION
Hi,

Here are some optimizations (with javadocs for the newly introduced classes and methods) and additionally some refined monitoring, you might want to integrate (or partially).
On top a json-exporter was introduced, that exports into the folder _featureElements_ (located in the same directory as e.g. _featureModels_), if present.

The 8 changes are concerning emf-stuff and fca.
_(For more details read the commit titles and answer me.)_

_Edit:_
The **commit** from the **13th March 2023 fixes** a performance problem in the feature identification of fca with weakly & strongly connected components. The ```contains``` on the formerly used List was in O(n), now when using a HashSet it is only in O(1). Before this fix this let to a **severe performance problem** e.g. for UML-models bigger or equally big than ArgoUML (summed up file size of variants: 80 MB) with the feature identification not terminating within 6 hours. (n was here 126,616 for the Core-block - to get an impression). Now this runs in a bit more than 6 minutes.  Only for small UML-models sized equally or smaller than PPU (summed up file size of variants: 0.4 MB) this was a small issue. But I'm sure everybody would appreciate it, if this ran faster. Not only foo like me, that want to analyze variants with summed up file sizes 250 or 500 MB.

_Edit2:_
Another way of fixing FeatureIDEUtils.isAncestorFeature1ofFeature2 (FeatureModel) can be found here: https://github.com/Robyt3/but4reuse/commit/85434d4a584561a4bad65aaf85c420ad920dcf39, but I guess this is less efficient.
Besides that Robyt3 has also an other fix in the fork: https://github.com/Robyt3/but4reuse/commit/57c8af9b91f155cbe7f4dc7747f71c2467c21a85 Namely fixing a null pointer exception in EMF Adapter, if the resource cannot be loaded.