### PR TITLE
Changes main

### DIFF
--- a/experimental/org.but4reuse.block.graphs/src/org/but4reuse/block/graphs/FCAWeaklyConnectedComponents.java
+++ b/experimental/org.but4reuse.block.graphs/src/org/but4reuse/block/graphs/FCAWeaklyConnectedComponents.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 
 import org.but4reuse.adaptedmodel.AdaptedArtefact;
 import org.but4reuse.adaptedmodel.AdaptedModelFactory;
@@ -47,7 +48,7 @@ public class FCAWeaklyConnectedComponents implements IBlockIdentification {
 			}
 			
 			// create graph
-			List<IElement> elements = AdaptedModelHelper.getElementsOfBlock(b);
+			HashSet<IElement> elements = AdaptedModelHelper.getElementsOfBlockHashSet(b);
 			DirectedGraph<IElement, DefaultEdge> graph = GraphUtils.createDirectedGraph(elements);
 			List<Set<IElement>> connectedSets = getConnectedSets(graph);
 			for (Set<IElement> connectedSet : connectedSets) {

--- a/experimental/org.but4reuse.graphs/src/org/but4reuse/graphs/utils/GraphUtils.java
+++ b/experimental/org.but4reuse.graphs/src/org/but4reuse/graphs/utils/GraphUtils.java
@@ -2,6 +2,7 @@ package org.but4reuse.graphs.utils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.but4reuse.adapters.IDependencyObject;
@@ -13,7 +14,7 @@ import org.jgrapht.graph.DefaultEdge;
 
 public class GraphUtils {
 	
-	public static DirectedGraph<IElement, DefaultEdge> createDirectedGraph(List<IElement> elements) {
+	public static DirectedGraph<IElement, DefaultEdge> createDirectedGraph(HashSet<IElement> elements) {
 		return createDirectedGraph(elements, false);
 	}
 
@@ -23,7 +24,7 @@ public class GraphUtils {
 	 * @param onlyContainment
 	 * @return A directed graph
 	 */
-	public static DirectedGraph<IElement, DefaultEdge> createDirectedGraph(List<IElement> elements,
+	public static DirectedGraph<IElement, DefaultEdge> createDirectedGraph(HashSet<IElement> elements,
 			boolean onlyContainment) {
 		DirectedGraph<IElement, DefaultEdge> graph = new DefaultDirectedGraph<IElement, DefaultEdge>(DefaultEdge.class);
 		// Add nodes

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
@@ -104,13 +104,19 @@ public class FCABlockIdentification implements IBlockIdentification {
 				fc.addPair(fc.getEntity("Artefact " + ia), attr);
 			}
 			R.remove(e);
+			monitor.subTask("Block Creation. Creating Blocks. Creating Formal Context." + R.size());
 		}
 
+		monitor.subTask("Block Creation. Creating concept lattice.");
 		// Generate concept lattice
 		ConceptOrder cl = FCAUtils.createConceptLattice(fc);
 		
 		// Add a block for each non empty concept
+		int i = 0;
+		final Set<Concept> concepts = cl.getConcepts();
+		final int is = concepts.size();
 		for (Concept c : cl.getConcepts()) {
+			monitor.subTask("Block Creation. Creating Blocks." + " " + ++i + "/" + is);
 			// getIntent returns also the intent of the parents, we are only
 			// interested in the getSimplifiedIntent which is the one that only
 			// belongs to this concept
@@ -129,6 +135,7 @@ public class FCABlockIdentification implements IBlockIdentification {
 			}
 		}
 
+		monitor.subTask("Block Creation. Sorting blocks by frequency.");
 		blocks = reorderBlocksByFrequency(R, blocks);
 
 		// finished

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
@@ -135,26 +135,14 @@ public class FCABlockIdentification implements IBlockIdentification {
 			}
 		}
 
-		monitor.subTask("Block Creation. Sorting blocks by frequency.");
-		blocks = reorderBlocksByFrequency(R, blocks);
+		monitor.subTask("Block Creation. Sorting blocks by descending frequency.");
+		// Java8's built-in sort produces an ascending order, when using standard compare/compareTo.
+		// We define the compare-method such that b1 is smaller than b0, if b1...size is bigger than b0...size.
+		// (Notice: If b1...size - b0...size > 0, this indicates the need of swapping b1 and b0.)
+		// This leads to the desired descending order of the b...size.
+		blocks.sort((b0, b1) -> b1.getOwnedBlockElements().get(0).getElementWrappers().size() - b0.getOwnedBlockElements().get(0).getElementWrappers().size());
 
 		// finished
 		return blocks;
 	}
-
-	// insertion sort
-	private List<Block> reorderBlocksByFrequency(LinkedHashMap<IElement, List<Integer>> R, List<Block> blocks) {
-		Block temp;
-		for (int i = 1; i < blocks.size(); i++) {
-			for (int j = i; j > 0; j--) {
-				if(blocks.get(j).getOwnedBlockElements().get(0).getElementWrappers().size() > blocks.get(j-1).getOwnedBlockElements().get(0).getElementWrappers().size()){
-					temp = blocks.get(j);
-					blocks.set(j, blocks.get(j - 1));
-					blocks.set(j - 1, temp);
-				}
-			}
-		}
-		return blocks;
-	}
-
 }

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
@@ -16,6 +16,7 @@ import org.but4reuse.adapters.IElement;
 import org.but4reuse.block.identification.IBlockIdentification;
 import org.but4reuse.fca.utils.FCAUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.common.util.EList;
 
 import fr.labri.galatea.Attribute;
 import fr.labri.galatea.BinaryAttribute;
@@ -57,7 +58,10 @@ public class FCABlockIdentification implements IBlockIdentification {
 
 			monitor.subTask("Block Creation. Preparation step " + (i + 1) + "/" + adaptedArtefacts.size());
 			AdaptedArtefact currentList = adaptedArtefacts.get(i);
-			for (ElementWrapper ew : currentList.getOwnedElementWrappers()) {
+			EList<ElementWrapper> ownedElementWrappers = currentList.getOwnedElementWrappers();
+			for(int j = 0; j < ownedElementWrappers.size(); ++j) {
+				ElementWrapper ew = ownedElementWrappers.get(j);
+				monitor.subTask("Block Creation. Preparation step " + (i + 1) + "/" + adaptedArtefacts.size() + " " + (j + 1) + "/" + ownedElementWrappers.size());
 
 				// user cancel
 				if (monitor.isCanceled()) {

--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/constraints/discovery/FCAConstraintsDiscovery.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/constraints/discovery/FCAConstraintsDiscovery.java
@@ -37,13 +37,23 @@ public class FCAConstraintsDiscovery implements IConstraintsDiscovery {
 
 		// REQUIRES
 		monitor.subTask("FCA: Checking Requires relations");
-		for (Concept c : cl.getConcepts()) {
+		final Set<Concept> concepts = cl.getConcepts();
+		int i = 0;
+		final int si = concepts.size();
+		for (Concept c : concepts) {
+			monitor.subTask("FCA: Check Requires relations. Concept " + i + "/" + si);
 			// getIntent returns also the intent of the parents,
 			// getSimplifiedIntent which is the one that only belongs to this
 			// concept
 			if (!c.getSimplifiedIntent().isEmpty()) {
-				for (Attribute owner : c.getSimplifiedIntent()) {
-					for (Attribute a : c.getIntent()) {
+				final Set<Attribute> simplifiedIntent = c.getSimplifiedIntent();
+				int k = 0;
+				for (Attribute owner : simplifiedIntent) {
+					monitor.subTask("FCA: Check Requires relations. Concept " + i + "/" + si +". Attribute " + k + "/" + simplifiedIntent.size());
+					final Set<Attribute> intent = c.getIntent();
+					int j = 0;
+					for (Attribute a : intent) {
+						monitor.subTask("FCA: Check Requires relations. Concept " + i + "/" + si+". Attribute " + k + "/" + simplifiedIntent.size() +". Attribute " + j + "/" + intent.size());
 						if (!owner.equals(a)) {
 							// if (!owner.sameAs(a)) {
 							// add constraint
@@ -53,9 +63,12 @@ public class FCAConstraintsDiscovery implements IConstraintsDiscovery {
 							constraint.addExplanation("Concept lattice found");
 							constraintList.add(constraint);
 						}
+						++j;
 					}
+					++k;
 				}
 			}
+			++i;
 		}
 
 		// EXCLUDES


### PR DESCRIPTION
Hi,

Here I have assembled the agreed parts to be merged into the main.

This are namely the additional monitoring, the 1 line block sorting and the performance improvement for weakly and strongly connected components.

To the 1 line block sorting I have added some comment in the source code (such that in future development it's hopefully quicker to understand, how the sorting works) and the monitor is now also telling the user it's done in descending order.

**Thanks for integrating the changes!**


**_Feel free to skip the remainder, it's a bit out dated._**

The following is elaborating on the performance problem in the feature identification of fca with weakly & strongly connected components:

The contains on the formerly used List was in O(n), now when using a HashSet it is only in O(1). Before this fix this let to a severe performance problem e.g. for UML-models bigger or equally big than ArgoUML (summed up file size of variants: 80 MB) with the feature identification not terminating within 6 hours. (n was here 126,616 for the Core-block - to get an impression). Now this runs in a bit more than 6 minutes. Only for small UML-models sized equally or smaller than PPU (summed up file size of variants: 0.4 MB) this was a small issue. But I'm sure everybody would appreciate it, if this ran faster. Not only foo like me, that want to analyze variants with summed up file sizes 250 or 500 MB.
