### PR TITLE
one line refactoring

### DIFF
--- a/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
+++ b/plugins/org.but4reuse.fca/src/org/but4reuse/fca/block/identification/FCABlockIdentification.java
@@ -69,19 +69,9 @@ public class FCABlockIdentification implements IBlockIdentification {
 				}
 
 				IElement e = (IElement) ew.getElement();
-				List<ElementWrapper> ews = eewmap.get(e);
-				if (ews == null) {
-					ews = new ArrayList<ElementWrapper>();
-				}
-				ews.add(ew);
-				eewmap.put(e, ews);
+				eewmap.computeIfAbsent(e, k -> new ArrayList<ElementWrapper>()).add(ew);
 
-				List<Integer> artefactIndexes = R.get(e);
-				if (artefactIndexes == null) {
-					artefactIndexes = new ArrayList<Integer>();
-				}
-				artefactIndexes.add(i);
-				R.put(e, artefactIndexes);
+				R.computeIfAbsent(e, k -> new ArrayList<Integer>()).add(i);
 			}
 		}
 


### PR DESCRIPTION
Hi,

in this branch the modification of map values for the maps ews and R is refactored using java.util.Map's computeIfAbsent.

I have done 4 measurements for the times the whole feature identification takes on the actual and this version on my machine for ArgoUML (10 files with about 8 MB each). The median for the actual version was 240 s and for this version 170 s. But I have to add it's not yet a solid study and only 3 out of 4 measurements were in the same range $\pm$ 5 s.

I think even in case further measurements show the same results, that less than 1 min difference is not the biggest deal. If the actual syntax is better readable, that might save the same time for a developer.